### PR TITLE
Adding psutil to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 azure-storage-blob==2.1.0
 deprecated
+psutil


### PR DESCRIPTION
azfuse requires `psutil` to be used.

I got the following error without using it:
```
Traceback (most recent call last):                                                                                                                                                                                                
  File "/home/alferre/code/azfuse_test.py", line 1, in <module>                                                                                                                                                                   
    from azfuse import File                                                                                                                                                                                                       
  File "/home/alferre/anaconda3/envs/mtdev/lib/python3.9/site-packages/azfuse/__init__.py", line 1, in <module>                                                                                                                   
    from .azfuse import File                                                                                                                                                                                                      
  File "/home/alferre/anaconda3/envs/mtdev/lib/python3.9/site-packages/azfuse/azfuse.py", line 1, in <module>                                                                                                                     
    from .common import exclusive_open_to_read                                                                                                                                                                                    
  File "/home/alferre/anaconda3/envs/mtdev/lib/python3.9/site-packages/azfuse/common.py", line 10, in <module>                                                                                                                    
    import psutil                                                                                                                                                                                                                 
ModuleNotFoundError: No module named 'psutil'                  
```